### PR TITLE
Custom Scrollbars to match Firefox Review

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1,6 +1,10 @@
 /*================ IMPORT COLORS ================*/
 @import "userColors.css";
 
+/*================ SCROLLBARS ================*/
+:root { scrollbar-color: #635d73 #323234 }
+*{ scrollbar-width: none }
+
 /*================== MAIN HEADER ==================*/
 toolbox#navigator-toolbox  {
 	border: 0 !important;

--- a/userContent.css
+++ b/userContent.css
@@ -1,6 +1,10 @@
 /*================ IMPORT COLORS ================*/
 @import "userColors.css";
 
+/*================ SCROLLBARS ================*/
+:root { scrollbar-color: #635d73 #323234 }
+*{ scrollbar-width: thin }
+
 /*================== FIREFOX BG COLOR ==================*/
 @-moz-document url("about:newtab"), url("about:home"), url("about:blank"), url("about:support"), url("about:config") {
 /*Light*/


### PR DESCRIPTION
I love this theme, but I'm picky about scrollbars. 

By making the change in userChrome.css, I removed scrollbars entirely from bookmark folders that are too long to display on-screen. (I have a bookmark problem.)

Making the change in userContent.css allows the scrollbars to take up less space on-screen while still keeping them present, in a place where they are actually useful. I also adjusted the colors to reflect the accent colors in Firefox Review. 

The only change I can't figure out is how to make the scrollbar track become transparent.

Regardless if you decide to reflect this in your code, I hope that you find this interesting at the least.